### PR TITLE
Add download link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Installation
 
-Copy `QLCommonMark.qlgenerator` to your `~/Library/QuickLook` or `/Library/QuickLook` folder.  If the plugin is not picked up immediately, you many need to run `qlmanage -r` from the Terminal.
+[Download `QLCommonMark.qlgenerator`](https://github.com/digitalmoksha/QLCommonMark/releases/download/v1.0/QLCommonMark.qlgenerator.zip) and copy it to your `~/Library/QuickLook` or `/Library/QuickLook` folder.  If the plugin is not picked up immediately, you may need to run `qlmanage -r` from the Terminal.
 
 ## Inspiration
 


### PR DESCRIPTION
I cloned and compiled this project in Xcode in order to try it out, having missed the download link for `QLCommonMark.qlgenerator` on the [releases page](https://github.com/digitalmoksha/QLCommonMark/releases), hidden in plain sight.

I've updated the readme to link users to the precompiled `.qlgenerator` file, hopefully saving future readers a similar sort of embarrassment. =)

Also, would you [consider publishing](https://github.com/caskroom/homebrew-cask/blob/master/CONTRIBUTING.md#adding-a-cask) this to the Homebrew-Cask registry? It'd be great to install this using `brew cask install qlcommonmark`. If so, you'll also need to attach an up-to-date version of the binary: one is currently missing from the [v1.1 release page](https://github.com/digitalmoksha/QLCommonMark/releases/tag/v1.1).

Thanks for the nifty plugin!